### PR TITLE
Update readme to fix typo in CollectContent config

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -784,7 +784,7 @@ The optional config can receive these properties:
     shouldTrim:true,//Default is true. Applies JS String.trim() method.
     getElementList:(elementList)=>{},  
     getElementContent:(elementContentString,pageAddress)=>{}//Called with each element collected.
-    getAllElements:(elements,address)=>{}//Called after an entire page has its elements collected.  
+    getAllItems: (items, address)=>{}//Called after an entire page has its elements collected.  
     slice:[start,end]
 }
 


### PR DESCRIPTION
The `CollectContent` configuration example incorrectly shows a handler named `getAllElements()` which is correctly reflected as `getAllItems()` within the code.  The documentation in the readme has been changed to reflect `getAllItems(items, address)` rather than `getAllElements(elements, address)`.