### PR TITLE
Add page address argument to `CollectContent`s config handler for `getAllElements()`

### DIFF
--- a/operations/CollectContent.js
+++ b/operations/CollectContent.js
@@ -67,7 +67,7 @@ class CollectContent extends Operation {
         // this.scraper.log(url,' Number of video elements: ',elementList.length)
 
         if (this.config.getElementList) {
-            await this.config.getElementList(elementList);
+            await this.config.getElementList(elementList, parentAddress);
         }
 
         const iterations = [];

--- a/readme.md
+++ b/readme.md
@@ -782,7 +782,7 @@ The optional config can receive these properties:
     name:'some name',
     contentType:'text',//Either 'text' or 'html'. Default is text.   
     shouldTrim:true,//Default is true. Applies JS String.trim() method.
-    getElementList:(elementList)=>{},  
+    getElementList:(elementList,pageAddress)=>{},  
     getElementContent:(elementContentString,pageAddress)=>{}//Called with each element collected.
     getAllElements:(elements,address)=>{}//Called after an entire page has its elements collected.  
     slice:[start,end]


### PR DESCRIPTION
Currently, the `getAllElements()` method provided by the `CollectContent` configuration does not receive a page address argument as part of the call.  I have added this argument to the call so that it can be consumed by the end user when doing complex scraping strategies.  I don't foresee this being a breaking change for your API, as it's just an extra arg in the args list but if you see an issue with it I'm happy to rewrite it however necessary!

The docs in the readme.md have also been updated as part of this PR to reflect the change.