### PR TITLE
Two new features

### DIFF
--- a/operations/CollectContent.js
+++ b/operations/CollectContent.js
@@ -9,17 +9,17 @@ const { createElementList, getNodeContent } = require('../utils/cheerio')
 class CollectContent extends Operation {
 
     /**
-     * 
-     * @param {string} querySelector cheerio-advanced-selectors selector 
-     * @param {Object} [config] 
+     *
+     * @param {string} querySelector cheerio-advanced-selectors selector
+     * @param {Object} [config]
      * @param {string} [config.name = 'Default CollectContent name']
      * @param {string} [config.contentType = 'text']
      * @param {number[]} [config.slice = null]
      * @param {boolean} [config.shouldTrim = true] Will trim the string, if "shouldTrim" is true.
      * @param {Function} [config.getElementList = null] Receives an elementList array
-     * @param {Function} [config.getElementContent = null] Receives elementContentString and pageAddress
+     * @param {Function} [config.getElementContent = null] Receives elementContentString, pageAddress, and element
      * @param {Function} [config.getAllItems = null] Receives all items collected from a specific page. Will run for each page.
-     
+
      */
     constructor(querySelector, config) {
         super(config);
@@ -41,9 +41,9 @@ class CollectContent extends Operation {
 
 
     /**
-    * 
-    * @param {{url:string,html:string}} params 
-    * @return {Promise<{type:string,name:string,data:[]}>} 
+    *
+    * @param {{url:string,html:string}} params
+    * @return {Promise<{type:string,name:string,data:[]}>}
     */
     async scrape({ html, url }) {
         // this.scraper.log('colelcting content',url)
@@ -53,7 +53,7 @@ class CollectContent extends Operation {
         // const arr = url.split('/');
         // const fileName = arr[arr.length-1]
         // fs.writeFile(`${this.scraper.config.logPath}/${fileName}.html`,html,()=>{})
-        
+
         const parentAddress = url
 
 
@@ -75,7 +75,7 @@ class CollectContent extends Operation {
         for (let element of elementList) {
             let content = getNodeContent(element, { shouldTrim: this.config.shouldTrim, contentType: this.config.contentType });
             if (this.config.getElementContent) {
-                const contentFromCallback = await this.config.getElementContent(content, parentAddress)
+                const contentFromCallback = await this.config.getElementContent(content, parentAddress, element)
                 content = typeof contentFromCallback === 'string' ? contentFromCallback : content;
             }
 

--- a/operations/OpenLinks.js
+++ b/operations/OpenLinks.js
@@ -14,7 +14,7 @@ const { mapPromisesWithLimitation } = require('../utils/concurrency');
 
 
 /**
- * 
+ *
  * @mixes CompositeInjectMixin
  * @mixes CompositeScrapeMixin
  */
@@ -22,20 +22,20 @@ class OpenLinks extends HttpOperation {//This operation is responsible for colle
 
 
     /**
-     * 
-     * @param {string} querySelector cheerio-advanced-selectors selector 
+     *
+     * @param {string} querySelector cheerio-advanced-selectors selector
      * @param {Object} [config]
-     * @param {string} [config.name = 'Default OpenLinks name']   
-     * @param {Object} [config.pagination = null] Look at the pagination API for more details.  
+     * @param {string} [config.name = 'Default OpenLinks name']
+     * @param {Object} [config.pagination = null] Look at the pagination API for more details.
      * @param {number[]} [config.slice = null]
      * @param {Function} [config.condition = null] Receives a Cheerio node.  Use this hook to decide if this node should be included in the scraping. Return true or false
-     * @param {Function} [config.getElementList = null] Receives an elementList array    
-     * @param {Function} [config.getPageData = null] 
+     * @param {Function} [config.getElementList = null] Receives an elementList array
+     * @param {Function} [config.getPageData = null]
      * @param {Function} [config.getPageObject = null] Receives a dictionary of children, and an address argument
-     * @param {Function} [config.getPageResponse = null] Receives an axiosResponse object    
+     * @param {Function} [config.getPageResponse = null] Receives an axiosResponse object
      * @param {Function} [config.getPageHtml = null] Receives htmlString and pageAddress
-     * @param {Function} [config.getException = null] Listens to every exception. Receives the Error object. 
-     *    
+     * @param {Function} [config.getException = null] Listens to every exception. Receives the Error object.
+     *
      */
 
     constructor(querySelector, config) {
@@ -48,11 +48,15 @@ class OpenLinks extends HttpOperation {//This operation is responsible for colle
         this.operations = [];//References to child operation objects.
         this.querySelector = querySelector;
 
+        this.transformHref = config?.transformHref ?? function (href) {
+            return href
+        }
+
     }
 
     /**
-     * 
-     * @param {Operation} Operation 
+     *
+     * @param {Operation} Operation
      */
     addOperation(Operation) {
         // this._addOperation(Operation);
@@ -76,8 +80,8 @@ class OpenLinks extends HttpOperation {//This operation is responsible for colle
 
 
     /**
-     * 
-     * @param {{url:string,html:string}} params 
+     *
+     * @param {{url:string,html:string}} params
      * @return {Promise<{type:string,name:string,data:[]}>}
      */
     async scrape({url,html}) {
@@ -97,7 +101,10 @@ class OpenLinks extends HttpOperation {//This operation is responsible for colle
 
         await mapPromisesWithLimitation(refs, async (href) => {
             // debugger;
-            const data = await this.pageHelper.processOneIteration(href, shouldPaginate)
+            const data = await this.pageHelper.processOneIteration(
+                this.transformHref(href),
+                shouldPaginate
+            )
 
             if (this.config.getPageData)
                 await this.config.getPageData(data);


### PR DESCRIPTION
# OpenLinks
- change: add `transformHref` function to config
  - this can be used to transform URLs found in the dom before they are opened. In my case, I was able to cut the number of requests needed in half.

# CollectContent -> getElementContent
- change: pass the actual element as
  - passing the element itself allows you to grab attribute data from the dom