### PR TITLE
Updates getElementContent to return all data types

### DIFF
--- a/operations/CollectContent.js
+++ b/operations/CollectContent.js
@@ -76,7 +76,7 @@ class CollectContent extends Operation {
             let content = getNodeContent(element, { shouldTrim: this.config.shouldTrim, contentType: this.config.contentType });
             if (this.config.getElementContent) {
                 const contentFromCallback = await this.config.getElementContent(content, parentAddress, element)
-                content = typeof contentFromCallback === 'string' ? contentFromCallback : content;
+                content = contentFromCallback ? contentFromCallback : content;
             }
 
             iterations.push(content);


### PR DESCRIPTION
### Context

Currently `getElementContent` only allows strings to be returned. I would like to extend it to return any data type, as I am returning objects and numbers in my scraping.